### PR TITLE
[푸코] Step01 - 로그인 화면 구현

### DIFF
--- a/Signup/Signup.xcodeproj/project.pbxproj
+++ b/Signup/Signup.xcodeproj/project.pbxproj
@@ -1,0 +1,367 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		D270C77F27F2CC300065D215 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D270C77E27F2CC300065D215 /* AppDelegate.swift */; };
+		D270C78127F2CC300065D215 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D270C78027F2CC300065D215 /* SceneDelegate.swift */; };
+		D270C78327F2CC300065D215 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D270C78227F2CC300065D215 /* LoginViewController.swift */; };
+		D270C78627F2CC300065D215 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D270C78427F2CC300065D215 /* Main.storyboard */; };
+		D270C78827F2CC310065D215 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D270C78727F2CC310065D215 /* Assets.xcassets */; };
+		D270C78B27F2CC310065D215 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D270C78927F2CC310065D215 /* LaunchScreen.storyboard */; };
+		D270C79327F2EBCB0065D215 /* SigninViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D270C79227F2EBCB0065D215 /* SigninViewController.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		D270C77B27F2CC300065D215 /* Signup.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Signup.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		D270C77E27F2CC300065D215 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		D270C78027F2CC300065D215 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		D270C78227F2CC300065D215 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
+		D270C78527F2CC300065D215 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		D270C78727F2CC310065D215 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		D270C78A27F2CC310065D215 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		D270C78C27F2CC310065D215 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D270C79227F2EBCB0065D215 /* SigninViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigninViewController.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		D270C77827F2CC300065D215 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		D270C77227F2CC300065D215 = {
+			isa = PBXGroup;
+			children = (
+				D270C77D27F2CC300065D215 /* Signup */,
+				D270C77C27F2CC300065D215 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		D270C77C27F2CC300065D215 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				D270C77B27F2CC300065D215 /* Signup.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		D270C77D27F2CC300065D215 /* Signup */ = {
+			isa = PBXGroup;
+			children = (
+				D270C77E27F2CC300065D215 /* AppDelegate.swift */,
+				D270C78027F2CC300065D215 /* SceneDelegate.swift */,
+				D270C78227F2CC300065D215 /* LoginViewController.swift */,
+				D270C79227F2EBCB0065D215 /* SigninViewController.swift */,
+				D270C78427F2CC300065D215 /* Main.storyboard */,
+				D270C78727F2CC310065D215 /* Assets.xcassets */,
+				D270C78927F2CC310065D215 /* LaunchScreen.storyboard */,
+				D270C78C27F2CC310065D215 /* Info.plist */,
+			);
+			path = Signup;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		D270C77A27F2CC300065D215 /* Signup */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D270C78F27F2CC310065D215 /* Build configuration list for PBXNativeTarget "Signup" */;
+			buildPhases = (
+				D270C77727F2CC300065D215 /* Sources */,
+				D270C77827F2CC300065D215 /* Frameworks */,
+				D270C77927F2CC300065D215 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Signup;
+			productName = Signup;
+			productReference = D270C77B27F2CC300065D215 /* Signup.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		D270C77327F2CC300065D215 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1330;
+				LastUpgradeCheck = 1330;
+				TargetAttributes = {
+					D270C77A27F2CC300065D215 = {
+						CreatedOnToolsVersion = 13.3;
+					};
+				};
+			};
+			buildConfigurationList = D270C77627F2CC300065D215 /* Build configuration list for PBXProject "Signup" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = D270C77227F2CC300065D215;
+			productRefGroup = D270C77C27F2CC300065D215 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				D270C77A27F2CC300065D215 /* Signup */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		D270C77927F2CC300065D215 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D270C78B27F2CC310065D215 /* LaunchScreen.storyboard in Resources */,
+				D270C78827F2CC310065D215 /* Assets.xcassets in Resources */,
+				D270C78627F2CC300065D215 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		D270C77727F2CC300065D215 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D270C79327F2EBCB0065D215 /* SigninViewController.swift in Sources */,
+				D270C78327F2CC300065D215 /* LoginViewController.swift in Sources */,
+				D270C77F27F2CC300065D215 /* AppDelegate.swift in Sources */,
+				D270C78127F2CC300065D215 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		D270C78427F2CC300065D215 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				D270C78527F2CC300065D215 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		D270C78927F2CC310065D215 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				D270C78A27F2CC310065D215 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		D270C78D27F2CC310065D215 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		D270C78E27F2CC310065D215 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		D270C79027F2CC310065D215 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = Q646ABLXY6;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Signup/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.codesquad.Signup;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		D270C79127F2CC310065D215 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = Q646ABLXY6;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Signup/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.codesquad.Signup;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		D270C77627F2CC300065D215 /* Build configuration list for PBXProject "Signup" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D270C78D27F2CC310065D215 /* Debug */,
+				D270C78E27F2CC310065D215 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D270C78F27F2CC310065D215 /* Build configuration list for PBXNativeTarget "Signup" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D270C79027F2CC310065D215 /* Debug */,
+				D270C79127F2CC310065D215 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = D270C77327F2CC300065D215 /* Project object */;
+}

--- a/Signup/Signup.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Signup/Signup.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Signup/Signup.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Signup/Signup.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Signup/Signup/AppDelegate.swift
+++ b/Signup/Signup/AppDelegate.swift
@@ -1,0 +1,36 @@
+//
+//  AppDelegate.swift
+//  Signup
+//
+//  Created by juntaek.oh on 2022/03/29.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/Signup/Signup/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Signup/Signup/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Signup/Signup/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Signup/Signup/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,93 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Signup/Signup/Assets.xcassets/Contents.json
+++ b/Signup/Signup/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Signup/Signup/Base.lproj/LaunchScreen.storyboard
+++ b/Signup/Signup/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Signup/Signup/Base.lproj/Main.storyboard
+++ b/Signup/Signup/Base.lproj/Main.storyboard
@@ -38,40 +38,6 @@
             </objects>
             <point key="canvasLocation" x="-1898.4615384615383" y="-594.31279620853081"/>
         </scene>
-        <!--Signin View Controller-->
-        <scene sceneID="Lnz-RK-Hin">
-            <objects>
-                <viewController storyboardIdentifier="SigninViewController" id="WYe-Np-Xlo" customClass="SigninViewController" customModule="Signup" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="Rg1-CV-3SX">
-                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <viewLayoutGuide key="safeArea" id="W3V-Ce-2zY"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                    </view>
-                    <navigationItem key="navigationItem" id="IaI-4d-wsf"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="BTI-za-J7C" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-389" y="58"/>
-        </scene>
-        <!--Navigation Controller-->
-        <scene sceneID="WEi-JX-t7g">
-            <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="afs-OL-Hjp" sceneMemberID="viewController">
-                    <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="lOq-0i-yuW">
-                        <rect key="frame" x="0.0" y="44" width="390" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <nil name="viewControllers"/>
-                    <connections>
-                        <segue destination="WYe-Np-Xlo" kind="relationship" relationship="rootViewController" id="BTh-D2-mjc"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="BdI-XZ-Szw" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-1408" y="58"/>
-        </scene>
     </scenes>
     <resources>
         <systemColor name="systemBackgroundColor">

--- a/Signup/Signup/Base.lproj/Main.storyboard
+++ b/Signup/Signup/Base.lproj/Main.storyboard
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_0" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Login View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="LoginViewController" customModule="Signup" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YMa-PE-pQe">
+                                <rect key="frame" x="174" y="64" width="42" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="YMa-PE-pQe" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="20" id="9Vj-N4-Iq5"/>
+                            <constraint firstItem="YMa-PE-pQe" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="jig-V1-ZAm"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="loginLabel" destination="YMa-PE-pQe" id="tie-DR-cn7"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1898.4615384615383" y="-594.31279620853081"/>
+        </scene>
+        <!--Signin View Controller-->
+        <scene sceneID="Lnz-RK-Hin">
+            <objects>
+                <viewController storyboardIdentifier="SigninViewController" id="WYe-Np-Xlo" customClass="SigninViewController" customModule="Signup" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Rg1-CV-3SX">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="W3V-Ce-2zY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="IaI-4d-wsf"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="BTI-za-J7C" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-389" y="58"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="WEi-JX-t7g">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="afs-OL-Hjp" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="lOq-0i-yuW">
+                        <rect key="frame" x="0.0" y="44" width="390" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="WYe-Np-Xlo" kind="relationship" relationship="rootViewController" id="BTh-D2-mjc"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="BdI-XZ-Szw" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1408" y="58"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Signup/Signup/Info.plist
+++ b/Signup/Signup/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Signup/Signup/LoginViewController.swift
+++ b/Signup/Signup/LoginViewController.swift
@@ -1,0 +1,143 @@
+//
+//  ViewController.swift
+//  Signup
+//
+//  Created by juntaek.oh on 2022/03/29.
+//
+
+import UIKit
+
+class LoginViewController: UIViewController {
+    @IBOutlet weak var loginLabel: UILabel!
+    private var idLabel: UILabel!
+    private var pswLabel: UILabel!
+    private var idTextField: UITextField!
+    private var pswTextField: UITextField!
+    private var loginButton: UIButton!
+    private var signinButton: UIButton!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = .systemBackground
+        
+        attributesConfigure()
+        hideKeyboardWithOutsideTapped()
+        
+        addSigninAction()
+    }
+    
+    private func attributesConfigure(){
+        loginLabelConfigure()
+        idLabelConfigure()
+        idTextFieldConfigure()
+        pswLabelConfigure()
+        pswTextFieldConfigure()
+        loginButtonConfigure()
+        signinButtonConfigure()
+    }
+}
+
+
+// MARK: - Use case: TextField Delegate and function
+
+extension LoginViewController: UITextFieldDelegate{
+    // 추후 ID, PW 확인 기능 필요
+    
+    private func hideKeyboardWithOutsideTapped(){
+        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tap.cancelsTouchesInView = false
+        self.view.addGestureRecognizer(tap)
+    }
+    
+    @objc func dismissKeyboard(){
+        self.view.endEditing(true)
+    }
+}
+
+
+// MARK: - Use case: Button action
+
+extension LoginViewController{
+    func addSigninAction(){
+        self.signinButton.addTarget(self, action: #selector(presentSigninVC), for: .touchUpInside)
+    }
+    
+    @objc func presentSigninVC(){
+        let signinVC = SigninViewController()
+        let navController = UINavigationController(rootViewController: signinVC)
+        
+        navController.modalPresentationStyle = .fullScreen
+        self.present(navController, animated: true)
+    }
+}
+
+
+// MARK: - Use case: Configure attributes
+
+extension LoginViewController{
+    private func loginLabelConfigure(){
+        loginLabel.text = "로그인"
+        loginLabel.font = UIFont.boldSystemFont(ofSize: 25)
+        loginLabel.textColor = .systemGreen
+    }
+    
+    private func idLabelConfigure(){
+        idLabel = UILabel(frame: CGRect(x: 40, y: loginLabel.frame.maxY + 30, width: view.frame.width - 80, height: 30))
+        idLabel.text = "아이디"
+        idLabel.font = UIFont.boldSystemFont(ofSize: 15)
+        
+        self.view.addSubview(idLabel)
+    }
+    
+    private func pswLabelConfigure(){
+        pswLabel = UILabel(frame: CGRect(x: 40, y: idTextField.frame.maxY + 20, width: view.frame.width - 80, height: 30))
+        pswLabel.text = "비밀번호"
+        pswLabel.font = UIFont.boldSystemFont(ofSize: 15)
+        
+        self.view.addSubview(pswLabel)
+    }
+    
+    private func idTextFieldConfigure(){
+        idTextField = UITextField(frame: CGRect(x: 40, y: idLabel.frame.maxY, width: view.frame.width - 80, height: 40))
+        textFieldCommonSetting(textField: idTextField)
+        
+        self.view.addSubview(idTextField)
+    }
+    
+    private func pswTextFieldConfigure(){
+        pswTextField = UITextField(frame: CGRect(x: 40, y: pswLabel.frame.maxY, width: view.frame.width - 80, height: 40))
+        textFieldCommonSetting(textField: pswTextField)
+        pswTextField.isSecureTextEntry = true
+        
+        self.view.addSubview(pswTextField)
+    }
+    
+    private func textFieldCommonSetting(textField: UITextField){
+        textField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: textField.frame.height))
+        textField.leftViewMode = UITextField.ViewMode.always
+        
+        textField.layer.cornerRadius = 2
+        textField.layer.borderWidth = 1
+        textField.layer.borderColor = UIColor.systemBlue.cgColor
+    }
+    
+    private func loginButtonConfigure(){
+        loginButton = UIButton(frame: CGRect(x: loginLabel.center.x - 90, y: pswTextField.frame.maxY + 30, width: 80, height: 40))
+        loginButton.setTitle("로그인", for: .normal)
+        loginButton.setTitleColor(.systemGreen, for: .normal)
+        loginButton.layer.borderWidth = 1
+        loginButton.layer.borderColor = UIColor.systemGray.cgColor
+        
+        self.view.addSubview(loginButton)
+    }
+    
+    private func signinButtonConfigure(){
+        signinButton = UIButton(frame: CGRect(x: loginLabel.center.x + 10, y: pswTextField.frame.maxY + 30, width: 80, height: 40))
+        signinButton.setTitle("회원가입", for: .normal)
+        signinButton.setTitleColor(.systemGreen, for: .normal)
+        signinButton.layer.borderWidth = 1
+        signinButton.layer.borderColor = UIColor.systemGray.cgColor
+        
+        self.view.addSubview(signinButton)
+    }
+}

--- a/Signup/Signup/SceneDelegate.swift
+++ b/Signup/Signup/SceneDelegate.swift
@@ -1,0 +1,52 @@
+//
+//  SceneDelegate.swift
+//  Signup
+//
+//  Created by juntaek.oh on 2022/03/29.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/Signup/Signup/SigninViewController.swift
+++ b/Signup/Signup/SigninViewController.swift
@@ -1,0 +1,17 @@
+//
+//  SigninViewController.swift
+//  Signup
+//
+//  Created by juntaek.oh on 2022/03/29.
+//
+
+import Foundation
+import UIKit
+
+class SigninViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = .white
+        self.title = "Sign"
+    }
+}


### PR DESCRIPTION
## 결과 화면
![Simulator Screen Recording - iPhone 13 Pro - 2022-03-29 at 17 37 12](https://user-images.githubusercontent.com/44107696/160581784-96193652-3255-412f-a081-fe31bc4b0ffa.gif)

## 작업 내역
- [x] 로그인 화면 구성
  - [x] 초기 화면으로서 회원가입 창으로 갈 수 있는 버튼도 추가 구현
  - [x] Label과 TextField 구현
    - [x] TextField 외부 클릭 시, 키보드 dismiss 구현
    - [ ] 키보드 return 선택 시, 키보드 dismiss 구현 필요
   - [x] 회원가입 버튼 클릭 시, modal present로 NavigationController의 rootVC인 SigninVC 이동
- [x] 회원가입 화면 생성

## 고민과 해결
- modal present를 통해서 NavigationController를 띄우는 부분을 구현할 때, navigationBar가 제대로 출력이 되지 않고 view의 출력도 어색한 점이 있었고 이를 해결할 방법을 한동안 찾지 못했습니다. 그러다 navigationController를 생성한 뒤, rootViewController에 해당 VC를 연결해야지 작동하는 것을 알게되었고 해당 로직으로 수정 후 스토리보드에 작성한 요소들은 삭제 진행하였습니다. 추가적으로 커스텀으로 VC를 생성할 때에는 view의 background가 .black으로 되어있기 때문에 색상 지정도 해줘야하는 부분 때문에 view의 출력이 어색했던 점도 확인할 수 있었습니다.

- model을 어떻게 구현할까 고민했습니다만 아직 로그인 화면 자체에 대한 본격적인 로직을 고민할 시점이 아닌 듯 하여, 이후에 로직을 고민하면서 model을 구현해보고자 합니다.

- 전체적인 속성들의 위치를 구현하는 데에 있어 타이틀 라벨인 loginLabel을 @IBOutlet으로 설정하여 중심점으로 두고 나머지 속성들은 서로의 위치를 기준으로 직접 작성하는 형태로 구현했습니다. 차후에 정리가 되면 오토레이아웃을 사용해보고자 합니다.